### PR TITLE
Update the examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,26 +17,26 @@ jobs:
     runs-on: ${{matrix.os}}
     steps:
       - uses: actions/checkout@v1
-      - uses: goto-bus-stop/setup-zig@v1.0.0
+      - uses: goto-bus-stop/setup-zig@v1.2.1
       - run: zig build test
   lint:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
-      - uses: goto-bus-stop/setup-zig@v1.0.0
+      - uses: goto-bus-stop/setup-zig@v1.2.1
       - run: zig fmt --check src/*.zig
 ```
 
 Optionally set a Zig version:
 ```yaml
-- uses: goto-bus-stop/setup-zig@v1.0.0
+- uses: goto-bus-stop/setup-zig@v1.2.1
   with:
     version: 0.4.0 # The default is 0.5.0
 ```
 
 To use the nightly builds, set:
 ```yaml
-- uses: goto-bus-stop/setup-zig@v1.0.0
+- uses: goto-bus-stop/setup-zig@v1.2.1
   with:
     version: master
 ```


### PR DESCRIPTION
The version of this action provided in examples was out of date compared
to the version of the most recent release.

This difference means that features like `version: master` will not
work.