### PR TITLE
Improve usage example

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: goto-bus-stop/setup-zig@v2
-      - run: zig fmt --check src/*.zig
+      - run: zig fmt --check .
 ```
 
 Optionally set a Zig version:


### PR DESCRIPTION
Run zig fmt --check  on root dir so that build.zig, build.zig.zon and any other folders containing zig source get checked