### PR TITLE
feat: verify downloaded zig version

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "@actions/core": "^1.2.2",
     "@actions/tool-cache": "^2.0.1",
     "semver": "^7.1.3",
-    "simple-get": "^4.0.0"
+    "simple-get": "^4.0.0",
+    "zig-minisign": "^0.1.3"
   },
   "devDependencies": {
     "esbuild": "^0.20.0",


### PR DESCRIPTION
Resolves #67 

I wrote a javascript shim to allow running zig-minisign in nodejs using WebAssembly and have used it to implement the signature verification feature.