### PR TITLE
Update CI version matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,20 +19,21 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-12, macos-latest, windows-latest]
         zig-version: [0.11.0, 0.12.0]
+        test-variant: modern
         include:
-          - { os: ubuntu-latest, zig-version: 0.5.0, legacy: true }
-          - { os: ubuntu-latest, zig-version: 0.7.0, legacy: true }
-          - { os: ubuntu-latest, zig-version: 0.8.0, legacy: true }
-          - { os: ubuntu-latest, zig-version: 0.9.0, legacy: true }
-          - { os: ubuntu-latest, zig-version: 0.10.0, legacy: true }
-          - { os: macos-12, zig-version: 0.7.0, legacy: true }
-          - { os: macos-12, zig-version: 0.8.0, legacy: true }
-          - { os: macos-latest, zig-version: 0.9.0, legacy: true }
-          - { os: macos-latest, zig-version: 0.10.0, legacy: true }
-          - { os: windows-latest, zig-version: 0.7.0, legacy: true }
-          - { os: windows-latest, zig-version: 0.8.0, legacy: true }
-          - { os: windows-latest, zig-version: 0.9.0, legacy: true }
-          - { os: windows-latest, zig-version: 0.10.0, legacy: true }
+          - { os: ubuntu-latest, zig-version: 0.5.0, test-variant: legacy }
+          - { os: ubuntu-latest, zig-version: 0.7.0, test-variant: legacy }
+          - { os: ubuntu-latest, zig-version: 0.8.0, test-variant: legacy }
+          - { os: ubuntu-latest, zig-version: 0.9.0, test-variant: legacy }
+          - { os: ubuntu-latest, zig-version: 0.10.0, test-variant: legacy }
+          - { os: macos-12, zig-version: 0.7.0, test-variant: legacy }
+          - { os: macos-12, zig-version: 0.8.0, test-variant: legacy }
+          - { os: macos-12, zig-version: 0.9.0, test-variant: legacy }
+          - { os: macos-12, zig-version: 0.10.0, test-variant: legacy }
+          - { os: windows-latest, zig-version: 0.7.0, test-variant: legacy }
+          - { os: windows-latest, zig-version: 0.8.0, test-variant: legacy }
+          - { os: windows-latest, zig-version: 0.9.0, test-variant: legacy }
+          - { os: windows-latest, zig-version: 0.10.0, test-variant: legacy }
     runs-on: ${{matrix.os}}
     steps:
       - name: Checkout sources
@@ -42,10 +43,10 @@ jobs:
         with:
           version: ${{matrix.zig-version}}
       - name: Run tests (zig up to v0.10.x)
-        if: ${{ matrix.legacy }}
+        if: ${{ matrix.test-variant == "legacy" }}
         run: zig build test
         working-directory: test/v0.10
       - name: Run tests (zig v0.11.x)
-        if: ${{ !matrix.legacy }}
+        if: ${{ matrix.test-variant == "modern" }}
         run: zig build test
         working-directory: test/v0.11

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-12, macos-latest, windows-latest]
         zig-version: [0.11.0, 0.12.0]
-        test-variant: modern
+        test-variant: [modern]
         include:
           - { os: ubuntu-latest, zig-version: 0.5.0, test-variant: legacy }
           - { os: ubuntu-latest, zig-version: 0.7.0, test-variant: legacy }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,10 +35,10 @@ jobs:
         with:
           version: ${{matrix.zig-version}}
       - name: Run tests (zig up to v0.10.x)
-        if: ${{ !startsWith(matrix.zig-version, '0.11.') }}
+        if: ${{ startsWith(matrix.zig-version, '0.7.') || startsWith(matrix.zig-version, '0.8.') || startsWith(matrix.zig-version, '0.9.') || startsWith(matrix.zig-version, '0.10.') }}
         run: zig build test
         working-directory: test/v0.10
       - name: Run tests (zig v0.11.x)
-        if: ${{ startsWith(matrix.zig-version, '0.11.') }}
+        if: ${{ !startsWith(matrix.zig-version, '0.7.') && !startsWith(matrix.zig-version, '0.8.') && !startsWith(matrix.zig-version, '0.9.') && !startsWith(matrix.zig-version, '0.10.') }}
         run: zig build test
         working-directory: test/v0.11

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,15 +17,22 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
-        zig-version: [0.7.0, 0.8.0, 0.9.0, 0.10.0, 0.11.0, 0.12.0]
+        os: [ubuntu-latest, macos-12, macos-latest, windows-latest]
+        zig-version: [0.11.0, 0.12.0]
         include:
-          - os: ubuntu-latest
-            zig-version: 0.5.0
-          - os: macos-12
-            zig-version: 0.7.0
-          - os: macos-12
-            zig-version: 0.8.0
+          - { os: ubuntu-latest, zig-version: 0.5.0, legacy: true }
+          - { os: ubuntu-latest, zig-version: 0.7.0, legacy: true }
+          - { os: ubuntu-latest, zig-version: 0.8.0, legacy: true }
+          - { os: ubuntu-latest, zig-version: 0.9.0, legacy: true }
+          - { os: ubuntu-latest, zig-version: 0.10.0, legacy: true }
+          - { os: macos-12, zig-version: 0.7.0, legacy: true }
+          - { os: macos-12, zig-version: 0.8.0, legacy: true }
+          - { os: macos-latest, zig-version: 0.9.0, legacy: true }
+          - { os: macos-latest, zig-version: 0.10.0, legacy: true }
+          - { os: windows-latest, zig-version: 0.7.0, legacy: true }
+          - { os: windows-latest, zig-version: 0.8.0, legacy: true }
+          - { os: windows-latest, zig-version: 0.9.0, legacy: true }
+          - { os: windows-latest, zig-version: 0.10.0, legacy: true }
     runs-on: ${{matrix.os}}
     steps:
       - name: Checkout sources
@@ -35,10 +42,10 @@ jobs:
         with:
           version: ${{matrix.zig-version}}
       - name: Run tests (zig up to v0.10.x)
-        if: ${{ startsWith(matrix.zig-version, '0.7.') || startsWith(matrix.zig-version, '0.8.') || startsWith(matrix.zig-version, '0.9.') || startsWith(matrix.zig-version, '0.10.') }}
+        if: ${{ matrix.legacy }}
         run: zig build test
         working-directory: test/v0.10
       - name: Run tests (zig v0.11.x)
-        if: ${{ !startsWith(matrix.zig-version, '0.7.') && !startsWith(matrix.zig-version, '0.8.') && !startsWith(matrix.zig-version, '0.9.') && !startsWith(matrix.zig-version, '0.10.') }}
+        if: ${{ !matrix.legacy }}
         run: zig build test
         working-directory: test/v0.11

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,10 +18,14 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        zig-version: [0.7.0, 0.8.0, 0.9.0, 0.10.0, 0.11.0]
+        zig-version: [0.7.0, 0.8.0, 0.9.0, 0.10.0, 0.11.0, 0.12.0]
         include:
           - os: ubuntu-latest
             zig-version: 0.5.0
+          - os: macos-12
+            zig-version: 0.7.0
+          - os: macos-12
+            zig-version: 0.8.0
     runs-on: ${{matrix.os}}
     steps:
       - name: Checkout sources

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,10 +43,10 @@ jobs:
         with:
           version: ${{matrix.zig-version}}
       - name: Run tests (zig up to v0.10.x)
-        if: ${{ matrix.test-variant == "legacy" }}
+        if: ${{ matrix.test-variant == 'legacy' }}
         run: zig build test
         working-directory: test/v0.10
       - name: Run tests (zig v0.11.x)
-        if: ${{ matrix.test-variant == "modern" }}
+        if: ${{ matrix.test-variant == 'modern' }}
         run: zig build test
         working-directory: test/v0.11


### PR DESCRIPTION
Adds zig 0.12.0 and runs both macos x86 and arm.

The check for which test to run now uses a `test-variant` flag. Old zig versions require a different test run due to breaking changes in the 0.10 line.